### PR TITLE
Add default landing page config option override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Default filter landing page configuration option as suggested by @surytrap
+
 ## [1.3.1] - 2026-01-17
 
 ### Fixed

--- a/src/config.lua
+++ b/src/config.lua
@@ -53,6 +53,9 @@ local config = {
 		Pinned = { Enable = true },
 		Banned = { Enable = true },
 	},
+	Filtering = {
+		DefaultLandingPage = MakeOverride(false, "All"),
+	},
 	AvailabilityStyle = {
 		Picked = {
 			Enable = true,
@@ -156,6 +159,12 @@ local configDesc = {
 	IconInRequirements = {
 		Pinned = { Enable = "Set to true to display pin icon next to pinned/tracked boons in the requirements list." },
 		Banned = { Enable = "Set to true to display locked icon next to banned boons in the requirements list." },
+	},
+	Filtering = {
+		DefaultLandingPage = MakeOverride(
+			"Enable setting a default filter landing page override",
+			"Acceptable values: Available, Unfulfilled, Unavailable, All"
+		),
 	},
 	AvailabilityStyle = {
 		Picked = {

--- a/src/reload.lua
+++ b/src/reload.lua
@@ -420,14 +420,32 @@ local Context = {
 	},
 }
 
+local function GetFilterIndex(filterName)
+	return game.GetIndex(Context.Filter.Values.Order, filterName)
+end
+
 function GetStartingFilterIndex(godName)
+	if config.Filtering.DefaultLandingPage.Override then
+		local filterName = config.Filtering.DefaultLandingPage.Value
+		local filterIndex = GetFilterIndex(filterName)
+		if filterIndex > 0 then
+			return filterIndex
+		else
+			modutil.mod.Print(
+				"Warning: couldn't load default landing page override value ("
+					.. tostring(filterName)
+					.. ")... Switching back to default behavior"
+			)
+		end
+	end
+
 	local metGodsLookup = GetMetGodsLookup()
 	if metGodsLookup[godName] then
-		return game.GetIndex(Context.Filter.Values.Order, "Available") -- Display available by default for met gods
+		return GetFilterIndex("Available") -- Display available by default for met gods
 	elseif game.CurrentHubRoom or godName == "PlayerUnit" then
-		return game.GetIndex(Context.Filter.Values.Order, "Unfulfilled") -- Display unfulfilled if we are not in a run or for Melinoe (Run Boon Overview compat)
+		return GetFilterIndex("Unfulfilled") -- Display unfulfilled if we are not in a run or for Melinoe (Run Boon Overview compat)
 	else
-		return game.GetIndex(Context.Filter.Values.Order, "Unavailable") -- Display unavailable otherwise
+		return GetFilterIndex("Unavailable") -- Display unavailable otherwise
 	end
 end
 


### PR DESCRIPTION
Resolves #32

Adds a default filter landing page override in the config file options. If the override is set to true, opening a codex page for any filtered god will try to land to that page if possible. 
Config option can easily be set through r2modman interface using the built-in dropdown menu or directly by modifying the config file or else through the imgui menu from Hell2Modding. 

_Note:_ If there are no boon to display in the set landing page, default behaviour of trying to show next page still apply.